### PR TITLE
Fixes https://bugzilla.opensuse.org/show_bug.cgi?id=1217299 zstd comp…

### DIFF
--- a/zypper-changelog
+++ b/zypper-changelog
@@ -147,7 +147,7 @@ list_of_xml_files = []
 # Find the cache file of the repositories
 for root, dirs, files in os.walk("/var/cache/zypp/raw/"):
     for file in files:
-        if file.endswith("primary.xml.gz"):
+        if file.endswith("primary.xml.zst") or file.endswith("primary.xml.gz"):
             if args.repos=="ALL":
                 list_of_xml_files.append(os.path.join(root, file))
             else:
@@ -179,11 +179,11 @@ for files in list_of_xml_files:
             mirror_url = repo.find('url').text
             log_text("Mirror URL: %s" % mirror_url)
 
-    zcat_process = subprocess.Popen(["zcat",
+    zstdcat_process = subprocess.Popen(["zstdcat",
                                      "%s" % files],
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
-    stdout_value, stderr_value = zcat_process.communicate()
+    stdout_value, stderr_value = zstdcat_process.communicate()
 
     tree = ET.ElementTree(ET.fromstring(stdout_value))
     root = tree.getroot()


### PR DESCRIPTION
…ression

the repodata is now compressed with zstd rather than gz so the search should be for primary.xml.zst and the process should be zstdcat instead of zcat.